### PR TITLE
Add basic POSIX Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+static-kas

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+prefix = /usr/local
+
+all: static-kas
+
+static-kas:
+	go build -o static-kas ./cmd
+
+clean:
+	rm static-kas
+
+install: static-kas
+	install -D static-kas $(DESTDIR)/$(prefix)/bin/static-kas


### PR DESCRIPTION
The DESTDIR and prefix macros are GNU conventions for Makefiles, might
help if one day static-kas ends up as a rpm / deb packages.