### PR TITLE
Mentions golang required version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Static KAS
 
-A fake kube-apiserver that serves static data from an Openshift must-gather. Dynamically discovers resources and supports logs.
+A fake kube-apiserver that serves static data from an Openshift must-gather. Dynamically discovers resources and supports logs. Requires golang >= 1.17.
 
 Usage:
 


### PR DESCRIPTION
Using golang 1.16 throw build errors, where every similar project (k8s) recommend to fix by going to 1.17.
1.17 fix that indeed.
