### PR TITLE
docs: "user" field is required for valid cluster config

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ clusters:
 contexts:
 - context:
     cluster: static-kas
+    user: ""
     namespace: default
   name: static-kas
 current-context: static-kas


### PR DESCRIPTION
Without this field, k9s will refuse to switch namespaces

Signed-off-by: Raphaël Pinson <raphael@isovalent.com>
