### PR TITLE
feat: add optional version.json file to return version information

### DIFF
--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -67,7 +67,17 @@ func New(l *zap.Logger, baseDir string) (*mux.Router, error) {
 	router := mux.NewRouter()
 	router.Use(loggingMiddleware(l))
 	router.HandleFunc("/version", func(w http.ResponseWriter, _ *http.Request) {
-		w.Write([]byte(`{}`))
+		data, err := os.ReadFile(filepath.Join(baseDir, "version.json"))
+		if err != nil {
+			if os.IsNotExist(err) {
+				l.Info("no version file found")
+			} else {
+				l.Error("failed to read version file, defaulting to empty")
+			}
+			w.Write([]byte(`{}`))
+			return
+		}
+		w.Write(data)
 	})
 	router.HandleFunc("/api", func(w http.ResponseWriter, _ *http.Request) {
 		d := metav1.APIVersions{TypeMeta: metav1.TypeMeta{Kind: "APIVersions"}, Versions: []string{"v1"}}

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -72,7 +72,7 @@ func New(l *zap.Logger, baseDir string) (*mux.Router, error) {
 			if os.IsNotExist(err) {
 				l.Info("no version file found")
 			} else {
-				l.Error("failed to read version file, defaulting to empty")
+				l.Error("failed to read version file, defaulting to empty", zap.Error(err))
 			}
 			w.Write([]byte(`{}`))
 			return

--- a/pkg/handler/testdata/version.json
+++ b/pkg/handler/testdata/version.json
@@ -1,0 +1,1 @@
+{"major":"1","minor":"21+","gitVersion":"v1.21.5-eks-bc4871b","gitCommit":"5236faf39f1b7a7dabea8df12726f25608131aa9","gitTreeState":"clean","buildDate":"2021-10-29T23:32:16Z","goVersion":"go1.16.8","compiler":"gc","platform":"linux/amd64"}


### PR DESCRIPTION
Note: the Cilium Sysdump tool dumps the Kubernetes server version as Go code, e.g.:

```go
version.Info{Major:"1", Minor:"21+", GitVersion:"v1.21.5-eks-bc4871b", GitCommit:"5236faf39f1b7a7dabea8df12726f25608131aa9", GitTreeState:"clean", BuildDate:"2021-10-29T23:32:16Z", GoVersion:"go1.16.8", Compiler:"gc", Platform:"linux/amd64"}
```

I think it's probably better to provide a JSON file as a standard (I actually don't see an easy way to parse the go version file in go).


Signed-off-by: Raphaël Pinson <raphael@isovalent.com>
