### PR TITLE
Invoking make should always cause invocation of go build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,9 @@ prefix = /usr/local
 
 all: static-kas
 
+# Let Go handle checking if recompilation is needed for ./static-kas
+.PHONY: static-kas
+
 static-kas:
 	go build -o static-kas ./cmd
 


### PR DESCRIPTION
It should be up to the Go toolchain to decide what needs recompilation,
Make is not equipped to do that