### PR TITLE
Some must-gathers have *.yaml files inside the ./namespaces folder

### DIFF
--- a/pkg/response/crossnamespace.go
+++ b/pkg/response/crossnamespace.go
@@ -60,6 +60,9 @@ func readAndDeserializeForAllNamespaces(parentDir, group, resource string) (*uns
 	result.SetAPIVersion("v1")
 	result.SetKind("List")
 	for _, namespace := range namespaces {
+		if !namespace.IsDir() {
+			continue
+		}
 		fromNamespace, err := ReadAndDeserializeList(path.Join(parentDir, namespace.Name(), group), resource)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read from namespace %s: %w", namespace.Name(), err)


### PR DESCRIPTION
These should be ignored when doing --all-namespaces, as they're not
directories we can find anything in, they're just yaml files