### PR TITLE
Automatically determine default container name when not given

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -12,6 +12,8 @@ import (
 	"github.com/alvaroaleman/static-kas/pkg/handler"
 )
 
+const Port string = "8080"
+
 type options struct {
 	baseDir string
 }
@@ -35,12 +37,12 @@ func main() {
 		l.Fatal("--base-dir is mandatory")
 	}
 
-	router, err := handler.New(l, o.baseDir)
+	router, err := handler.New(l, o.baseDir, Port)
 	if err != nil {
 		l.Fatal("failed to construct server", zap.Error(err))
 	}
 
-	if err := http.ListenAndServe(":8080", router); err != nil {
+	if err := http.ListenAndServe(fmt.Sprintf(":%s", Port), router); err != nil {
 		l.Error("server ended", zap.Error(err))
 	}
 }

--- a/pkg/handler/testdata/namespaces/openshift-network2-operator/core/pods.yaml
+++ b/pkg/handler/testdata/namespaces/openshift-network2-operator/core/pods.yaml
@@ -1,0 +1,85 @@
+---
+apiVersion: v1
+items:
+- apiVersion: v1
+  kind: Pod
+  metadata:
+    creationTimestamp: "2022-03-04T18:04:45Z"
+    generateName: network-operator2-7887564c4-
+    labels:
+      name: network-operator2
+      pod-template-hash: 7887564c4
+    name: network-operator2-7887564c4-mjg9d
+    namespace: openshift-network2-operator
+    ownerReferences:
+    - apiVersion: apps/v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: ReplicaSet
+      name: network-operator-7887564c4
+      uid: 19c3c4c8-939e-408f-948c-f6bfbd779bca
+    resourceVersion: "4233"
+    uid: 39dc70fa-1a47-4d3a-b1dd-53c3b2a006b9
+  spec:
+    containers:
+    - command:
+      - /bin/command1
+      image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:1d57d0ddce50f786694e3651a814eb910ed289daa2747870d71abb2525495538
+      imagePullPolicy: IfNotPresent
+      name: container1
+    - command:
+      - /bin/command2
+      image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:1d57d0ddce50f786694e3651a814eb910ed289daa2747870d71abb2525495538
+      imagePullPolicy: IfNotPresent
+      name: container2
+  status:
+    conditions:
+    - lastProbeTime: null
+      lastTransitionTime: "2022-03-04T18:06:16Z"
+      status: "True"
+      type: Initialized
+    - lastProbeTime: null
+      lastTransitionTime: "2022-03-04T18:06:21Z"
+      status: "True"
+      type: Ready
+    - lastProbeTime: null
+      lastTransitionTime: "2022-03-04T18:06:21Z"
+      status: "True"
+      type: ContainersReady
+    - lastProbeTime: null
+      lastTransitionTime: "2022-03-04T18:06:16Z"
+      status: "True"
+      type: PodScheduled
+    containerStatuses:
+    - containerID: cri-o://b21f2abe35711b8da4ebe9e28366f08c78e06f4d573560dc2d7a2da35dd56dca
+      image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:1d57d0ddce50f786694e3651a814eb910ed289daa2747870d71abb2525495538
+      imageID: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:1d57d0ddce50f786694e3651a814eb910ed289daa2747870d71abb2525495538
+      lastState: {}
+      name: container1
+      ready: true
+      restartCount: 0
+      started: true
+      state:
+        running:
+          startedAt: "2022-03-04T18:06:20Z"
+    - containerID: cri-o://b21f2abe35711b8da4ebe9e28366f08c78e06f4d573560dc2d7a2da35dd56dca
+      image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:1d57d0ddce50f786694e3651a814eb910ed289daa2747870d71abb2525495538
+      imageID: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:1d57d0ddce50f786694e3651a814eb910ed289daa2747870d71abb2525495538
+      lastState: {}
+      name: container2
+      ready: true
+      restartCount: 0
+      started: true
+      state:
+        running:
+          startedAt: "2022-03-04T18:06:20Z"
+    hostIP: 10.0.133.157
+    phase: Running
+    podIP: 10.0.133.157
+    podIPs:
+    - ip: 10.0.133.157
+    qosClass: Burstable
+    startTime: "2022-03-04T18:06:16Z"
+kind: PodList
+metadata:
+  resourceVersion: "188150"

--- a/pkg/handler/testdata/namespaces/openshift-network2-operator/pods/network-operator2-7887564c4-mjg9d/network-operator2/network-operator2/logs/current.log
+++ b/pkg/handler/testdata/namespaces/openshift-network2-operator/pods/network-operator2-7887564c4-mjg9d/network-operator2/network-operator2/logs/current.log
@@ -1,0 +1,2 @@
+Current first line
+Current second line


### PR DESCRIPTION
# Background

Older versions of kubectl/oc, when ran as `kubectl logs -n <namespace> <name>`,
first try to GET the pod resource requested, if they see there's only one container in
it, they will then try to GET:

`http://<api>/api/v1/namespaces/<namespace>/pods/<name>/log`

Without any `container=...` query param (newer versions of kubectl/oc
always specify this query parameter regardless). The behavior of the
regular kubernetes API server in this scenario is that when the pod has
only a single container, the logs for that only container are returned.
If the pod has more than one pod, an error response is returned, listing
the names of the containers in the pod.

# Issue

static-kas works fine when the container name is given in the query
param (which is the case for newer oc/kubectl clients), but breaks down
when the container parameter is omitted.

# Solution

static-kas will now better imitate the behavior of the regular
kubernetes API server