### PR TITLE
`/apis` endpoint should have json content type

### DIFF
--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -221,6 +221,7 @@ func New(l *zap.Logger, baseDir string, port string) (*mux.Router, error) {
 		}
 	}).Methods(http.MethodGet)
 	router.HandleFunc("/apis", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
 		w.Write(serializedGroupList)
 	}).Methods(http.MethodGet)
 	for groupVersion := range groupSerializedResourceListMap {


### PR DESCRIPTION
Since it's already serialized it doesn't go through `serializeAndWrite`
and so we don't set `Content-Type`

Having the wrong `Content-Type` seems to cause issues with newer
versions of `oc`, as it worked fine before and I think my `oc` version
is the only thing that changed