### PR TITLE
Ignore empty files

### DIFF
--- a/pkg/discovery/discovery.go
+++ b/pkg/discovery/discovery.go
@@ -56,6 +56,10 @@ func Discover(l *zap.Logger, basePath string) (map[string]*metav1.APIResourceLis
 				return
 			}
 
+			if len(raw) == 0 {
+				return
+			}
+
 			u := &unstructured.Unstructured{}
 			if err := yaml.Unmarshal(raw, u); err != nil {
 				errs.add(fmt.Errorf("failed to decode %s into an unstructured: %w", path, err))


### PR DESCRIPTION
OpenShift gathers have some file called
`./pod_network_connectivity_check/podnetworkconnectivitychecks.yaml`
that is sometimes empty and this leads to a `""` groupVersion being
parsed which later leads to static-kas failing to start down the line