### PR TITLE
Support sendInitialEvents=true on WATCH

### DIFF
--- a/pkg/handler/handler_test.go
+++ b/pkg/handler/handler_test.go
@@ -557,6 +557,37 @@ func TestServer(t *testing.T) {
 			),
 		},
 		{
+			name: "Watch with sendInitialEvents sends BOOKMARK",
+			run: func(t *testing.T) {
+				watchCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+				defer cancel()
+				req, err := http.NewRequestWithContext(watchCtx, http.MethodGet, "http://127.0.0.1:8080/api/v1/pods?watch=true&sendInitialEvents=true", nil)
+				if err != nil {
+					t.Fatalf("failed to build request: %v", err)
+				}
+				resp, err := http.DefaultClient.Do(req)
+				if err != nil {
+					t.Fatalf("request failed: %v", err)
+				}
+				defer resp.Body.Close()
+				decoder := json.NewDecoder(resp.Body)
+				var gotBookmark bool
+				for decoder.More() {
+					var ev metav1.WatchEvent
+					if err := decoder.Decode(&ev); err != nil {
+						break
+					}
+					if ev.Type == "BOOKMARK" {
+						gotBookmark = true
+						break
+					}
+				}
+				if !gotBookmark {
+					t.Error("expected BOOKMARK event after ADDED events")
+				}
+			},
+		},
+		{
 			name: "List response is sorted",
 			run: func(t *testing.T) {
 				podList := &corev1.PodList{}

--- a/pkg/response/common.go
+++ b/pkg/response/common.go
@@ -34,6 +34,24 @@ func respondToWatch(r *http.Request, w http.ResponseWriter, objects ...runtime.O
 			return fmt.Errorf("failed to write watch item: %w", err)
 		}
 	}
+	// Send a BOOKMARK so clients using WatchList (sendInitialEvents=true)
+	// know the initial list is complete.
+	if r.URL.Query().Get("sendInitialEvents") == "true" {
+		// KEP-3157: client-go >=0.32 collapses List+Watch into a single
+		// watch with sendInitialEvents=true. The reflector expects a
+		// BOOKMARK with this annotation to mark the end of the initial
+		// synthetic list — without it, it waits ~10s then silently gives
+		// up showing zero results. Unstructured because the bookmark
+		// carries no real data and we don't know the concrete type here.
+		// ResourceVersion "0": static-kas serves a snapshot, no real
+		// version ordering to preserve.
+		bookmark := &unstructured.Unstructured{}
+		bookmark.SetResourceVersion("0")
+		bookmark.SetAnnotations(map[string]string{"k8s.io/initial-events-end": "true"})
+		if err := writeJSON(&metav1.WatchEvent{Type: "BOOKMARK", Object: runtime.RawExtension{Object: bookmark}}, w); err != nil {
+			return fmt.Errorf("failed to write bookmark: %w", err)
+		}
+	}
 	if f, ok := w.(http.Flusher); ok {
 		f.Flush()
 	}


### PR DESCRIPTION
Background:

Some clients use client-go >=0.32 which enables the WatchListClient
feature gate by default.

Instead of the traditional List then Watch sequence, it sends a single
watch request with sendInitialEvents=true and expects:
  1. ADDED events for all existing objects
  2. A BOOKMARK event with annotation "k8s.io/initial-events-end" to
     signal the initial list is complete
  3. Continued watch events for real-time changes

Problem:

static-kas sends the ADDED events but never BOOKMARK. client-go's
reflector waits ~10s for it, then silently gives up — resulting in zero
resources displayed in tools like k9s (which uses client-go v0.35.3).

The failure was invisible because k9s suppresses all klog output.

Feature detection didn't help: static-kas returned 200 and streamed
ADDED events, so client-go believed WatchList was supported.

Solution:

When sendInitialEvents=true is present, send a BOOKMARK event after all
ADDED events with the required annotation and a synthetic
resourceVersion.

Alternative considered:

Reject unknown query parameters (like sendInitialEvents in this case)
with 4xx so client-go falls back to traditional List+Watch. But it was
easy enough to implement so I chose the other solution

Note:

This might've been surfaced by the existing tests had we upgraded the
client-go used by the tests to a more recent version

Why this didn't happen with oc:

```
$ KUBECONFIG=/tmp/skas-kubeconfig.yaml oc get pods -A -v=8 2>&1 | grep "GET.*pods"

I0623 15:53:01.001128 3093364 round_trippers.go:527] "Request" verb="GET" url="http://localhost:8080/api/v1/pods?limit=500" headers=<
```

oc does a plain GET /api/v1/pods?limit=500 (traditional List), no watch / sendInitialEvents. oc get doesn't use informers, So WatchList never comes into play.

k9s uses informers (persistent List+Watch cache) because it's a live TUI that needs to update in real time. That's why it hits the WatchList path and oc doesn't.

Assisted-by: Claude <noreply@anthropic.com>
